### PR TITLE
General improvements for Config, GoogleDrive2 classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ galaxy
 /.settings/
 /.classpath
 /.project
+/.idea
+
+# environment files
+**/*.env

--- a/board.foo
+++ b/board.foo
@@ -1,3 +1,0 @@
-
-GITHUB_API_TOKEN=ef1f8b4052b88a2fc36b2170ee0853587d854724
-GD_CREDENTIALS=file:/Users/mdobozy/Downloads/mdobozy-ninja-board-7103216dead0.json

--- a/board.foo
+++ b/board.foo
@@ -1,0 +1,3 @@
+
+GITHUB_API_TOKEN=ef1f8b4052b88a2fc36b2170ee0853587d854724
+GD_CREDENTIALS=file:/Users/mdobozy/Downloads/mdobozy-ninja-board-7103216dead0.json

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,15 @@
 					</systemProperty>
 				</configuration>
 			</plugin>
-		</plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
 	</build>
 	
 	<profiles>
@@ -134,6 +142,12 @@
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<version>1.2.17</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.github.cdimascio</groupId>
+			<artifactId>java-dotenv</artifactId>
+			<version>5.1.1</version>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/com/redhat/sso/ninja/Config.java
+++ b/src/main/java/com/redhat/sso/ninja/Config.java
@@ -1,74 +1,85 @@
 package com.redhat.sso.ninja;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.nio.file.Files;
-import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
 
+import io.github.cdimascio.dotenv.Dotenv;
+import io.github.cdimascio.dotenv.DotenvEntry;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
-import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.map.JsonMappingException;
 
 import com.redhat.sso.ninja.utils.IOUtils2;
 import com.redhat.sso.ninja.utils.Json;
-import com.redhat.sso.ninja.utils.MapBuilder;
 
 public class Config {
-  private static final Logger log=Logger.getLogger(Config.class);
-  public static final File STORAGE=new File("target/ninja-persistence", "config.json");
+  private static final Logger log = Logger.getLogger(Config.class);
+  private static final File STORAGE = new File("target/ninja-persistence", "config.json");
   private static Config instance;
-  private List<Map<String,Object>> scripts=null;
-  private Map<String,String> options=null;
-  private Map<String,Object> values=null;
-  
-  
-  public Config(){}
-  public Config(String json){
-    System.out.println("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX="+json);
-    try{
-      Config x=Json.newObjectMapper(true).readValue(json, Config.class);
-      this.options=x.options;
-      this.scripts=x.scripts;
-      this.values=x.values;
-      instance=this;
-    }catch (JsonParseException e){
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    }catch (JsonMappingException e){
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    }catch (IOException e){
-      // TODO Auto-generated catch block
-      e.printStackTrace();
+  private List<Map<String, Object>> scripts = null;
+  private Map<String, String> options = null;
+  private Map<String, Object> values = null;
+
+
+  public Config() {
+  }
+
+  public Config(String json) {
+    System.out.println("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=" + json);
+    try {
+      Config x = Json.newObjectMapper(true).readValue(json, Config.class);
+      this.options = x.options;
+      this.scripts = x.scripts;
+      this.values = x.values;
+      instance = this;
+    } catch (IOException e) {
+      log.error("Error parsing config.json: ", e);
+      throw new IllegalStateException(e);
     }
   }
-  
+
   // Config options to be able to configure
   // - cycle/zero points every X weeks (or would you want a rolling total?)
   // - multiple pools per user
   // - each pool much have a configurable way of pulling the info (groovy?)
   // - each pool points must have a configurable way of calculating the multiple pool values into a consolidated perception of score
   // - Heartbeat to pull data from last time it was run - must be persistent and survive server restarts
-  
-  
-  
-  
-  public Map<String,String> getOptions() {if (options==null) options=new HashMap<String, String>(); return options;}
-  public List<Map<String,Object>> getScripts() {if (scripts==null) scripts=new ArrayList<Map<String, Object>>(); return scripts;}
-  public Map<String,Object> getValues() {if (values==null) values=new HashMap<String, Object>(); return values;}
-  
+
+
+  /**
+   * Gets a specific option from the configs
+   *
+   * @param key The option to retrieve
+   * @return The option, or null if it does not exist.
+   */
+  public String getOption(String key) {
+    return get().getOptions().get(key);
+  }
+
+  public String getEnvOption(String key) {
+    return get().getOptions().get("ENV." + key);
+  }
+
+  public Map<String, String> getOptions() {
+    if (options == null) options = new HashMap<>();
+    return options;
+  }
+
+  public List<Map<String, Object>> getScripts() {
+    if (scripts == null) scripts = new ArrayList<>();
+    return scripts;
+  }
+
+  public Map<String, Object> getValues() {
+    if (values == null) values = new HashMap<>();
+    return values;
+  }
+
 //  class MapBuilder<K,V>{
 //    Map<K, V> values=new HashMap<K, V>();
 //    public MapBuilder<K,V> put(K key, V value){
@@ -78,36 +89,42 @@ public class Config {
 //      return values;
 //    }
 //  }
-  
-  
-  public void save(){
-    try{
-      if (!Config.STORAGE.getParentFile().exists()){
-      	log.info("Config storage folder didn't exist - creating new folder to store config");
-      	Config.STORAGE.getParentFile().mkdirs();
+
+
+  public void save() {
+    try {
+      if (!Config.STORAGE.getParentFile().exists()) {
+        log.info("Config storage folder didn't exist - creating new folder to store config");
+        Files.createDirectories(Paths.get(Config.STORAGE.getParentFile().getAbsolutePath()));
       }
       IOUtils2.writeAndClose(Json.newObjectMapper(true).writeValueAsString(instance).getBytes(), new FileOutputStream(Config.STORAGE));
-      log.info("Config saved (size="+Config.STORAGE.length()+")");
-    }catch (IOException e){
-      e.printStackTrace();
+      log.info("Config saved (size=" + Config.STORAGE.length() + ")");
+    } catch (IOException e) {
+      log.error("Error saving configuration: ", e);
+      throw new IllegalStateException(e);
     }
   }
-  
-  public static Config get(){
-    if (instance==null){
-      try{
-        if (!Config.STORAGE.exists()){
-        	log.info("Config file doesn't exist, creating default one here: "+STORAGE.getAbsolutePath());
-          if (!Config.STORAGE.getParentFile().exists()) Config.STORAGE.getParentFile().mkdirs();
+
+  public static Config get() {
+    if (instance == null) {
+      try {
+        if (!Config.STORAGE.exists()) {
+          log.info("Config file doesn't exist, creating default one here: " + STORAGE.getAbsolutePath());
+          if (!Config.STORAGE.getParentFile().exists()) {
+            Files.createDirectories(Paths.get(Config.STORAGE.getParentFile().getAbsolutePath()));
+          }
           // copy the default config over
-          IOUtils.copy(Config.class.getClassLoader().getResourceAsStream(STORAGE.getName()), new FileOutputStream(STORAGE));
-          
+          InputStream is = Config.class.getClassLoader().getResourceAsStream(STORAGE.getName());
+          if (is != null) {
+            IOUtils.copy(is, new FileOutputStream(STORAGE));
+          }
+
         }
 //          instance=new Config();
 //        }else{
-          log.info("Config loading (size="+Config.STORAGE.length()+")");
-          String toLoad=IOUtils2.toStringAndClose(new FileInputStream(Config.STORAGE));
-          instance=Json.newObjectMapper(true).readValue(new ByteArrayInputStream(toLoad.getBytes()), Config.class);
+        log.info("Config loading (size=" + Config.STORAGE.length() + ")");
+        String toLoad = IOUtils2.toStringAndClose(new FileInputStream(Config.STORAGE));
+        instance = Json.newObjectMapper(true).readValue(new ByteArrayInputStream(toLoad.getBytes()), Config.class);
 //        }
 //        UserController uc=new UserController();
 //        GoogleAddressResolution gar=new CachedGoogleAddressResolution(false);
@@ -132,33 +149,44 @@ public class Config {
 //          String str=Json.newObjectMapper(false).writeValueAsString(instance);
 //          IOUtils2.writeAndClose(str.getBytes(), new FileOutputStream(new File("config2.json")));
 //        }
-        
-      }catch(Exception e){
-        e.printStackTrace();
-        instance=new Config();
+
+        /* load the entries from the environment file, if one exists */
+        Dotenv env = Dotenv
+            .configure()
+            .filename("board.env")
+            .ignoreIfMissing()
+            .load();
+        for (DotenvEntry entry : env.entries()) {
+          instance.getOptions().put("ENV." + entry.getKey(), entry.getValue());
+        }
+
+      } catch (Exception e) {
+        log.error("Error instantiating configuration: ", e);
+        throw new IllegalStateException(e);
       }
     }
     return instance;
   }
-  
-  public void setOptions(Map<String,String> value) {
-    this.options=value;
+
+  public void setOptions(Map<String, String> value) {
+    this.options = value;
   }
-  
+
   @JsonIgnore
-  public String getNextTaskNum(){
+  public String getNextTaskNum() {
 //  	Config cfg=Config.get();
-  	
-  	if (!getValues().containsKey("lastTaskNum")){
-  		getValues().put("lastTaskNum", 0);
-  	}
-  	
-  	int result=1+(Integer)getValues().get("lastTaskNum");
-  	getValues().put("lastTaskNum", result);
-  	save();
-  	
-  	return String.valueOf(result);
+
+    if (!getValues().containsKey("lastTaskNum")) {
+      getValues().put("lastTaskNum", 0);
+    }
+
+    int result = 1 + (Integer) getValues().get("lastTaskNum");
+    getValues().put("lastTaskNum", result);
+    save();
+
+    return String.valueOf(result);
   }
+
 }
 
 

--- a/src/main/java/com/redhat/sso/ninja/GoogleDrive2.java
+++ b/src/main/java/com/redhat/sso/ninja/GoogleDrive2.java
@@ -1,11 +1,20 @@
 package com.redhat.sso.ninja;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import com.redhat.sso.ninja.utils.DownloadFile;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.log4j.Logger;
+import org.apache.poi.xssf.usermodel.XSSFCell;
+import org.apache.poi.xssf.usermodel.XSSFRow;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,176 +23,228 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
-import org.apache.poi.xssf.usermodel.XSSFCell;
-import org.apache.poi.xssf.usermodel.XSSFRow;
-import org.apache.poi.xssf.usermodel.XSSFSheet;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-
-import com.redhat.sso.ninja.utils.DownloadFile;
-
 public class GoogleDrive2 {
-  private static Logger log=Logger.getLogger(GoogleDrive2.class); 
-	
-  public static final String DEFAULT_EXECUTABLE="/home/%s/drive_linux";
-//  public static final String DEFAULT_PULL_COMMAND=DEFAULT_EXECUTABLE+" pull -export xls -quiet=true --id %s"; //worked with 0.3.1
-  public static final String DEFAULT_PULL_COMMAND=DEFAULT_EXECUTABLE+" pull -export xls -no-prompt --id %s"; // 0.3.7+ changed its output that we parse
-  public static final String DEFAULT_WORKING_FOLDER="/home/%s/google_drive";
-  
-  private String googleSheetPullCommand;
-  private String googleSheetWorkingFolder;
-  
-  public static String getDefaultExecutable(){
-    return String.format(DEFAULT_EXECUTABLE, System.getProperty("user.name"));
-  }
-  public static String getDefaultWorkingFolder(){
-    return String.format(DEFAULT_WORKING_FOLDER, System.getProperty("user.name"));
-  }
-  
-  public GoogleDrive2(){
-    this.googleSheetPullCommand=DEFAULT_PULL_COMMAND;
-    this.googleSheetWorkingFolder=DEFAULT_WORKING_FOLDER;
-  }
-  public GoogleDrive2(String googleSheetPullCommand, String googleSheetWorkingFolder){
-    this.googleSheetPullCommand=googleSheetPullCommand;
-    this.googleSheetWorkingFolder=googleSheetWorkingFolder;
-  }
 
-  public File downloadFile(String fileId) throws IOException, InterruptedException {
-    String command = String.format(googleSheetPullCommand, System.getProperty("user.name"), fileId);
-    
-    String googleDrivePath=String.format(googleSheetWorkingFolder, System.getProperty("user.name"));
-    File workingFolder=new File(googleDrivePath);
-    workingFolder.mkdirs(); // just in case it's not there
-    System.out.println("Using working folder: "+workingFolder.getAbsolutePath());
-    System.out.println("Downloading google file: "+fileId);
-    System.out.println("Command: "+command);
-    
-    if (googleDrivePath.contains("google")){
-      recursivelyDelete(workingFolder);
-    }else
-      System.out.println("Not cleaning working folder unless it contains the name 'google' - for safety reasons");
-    
-    Process exec = Runtime.getRuntime().exec(command, null, workingFolder);
-    
-    exec.waitFor();
-    String syserr = IOUtils.toString(exec.getErrorStream());
-    String sysout = IOUtils.toString(exec.getInputStream());
-    System.out.println("sysout=\""+sysout+"\"; syserr=\""+syserr+"\"");
-    if (!sysout.contains("Resolving...") && !sysout.contains("Everything is up-to-date"))
-      throw new RuntimeException("Error running google drive script: " + sysout);
-    if (!sysout.contains("Everything is up-to-date")) {
-      // System.out.println("Do Nothing");
-      // return null;
-      // } else {
-      Pattern p = Pattern.compile("to '(.+)'$");
-      Matcher matcher = p.matcher(sysout);
-      if (matcher.find()){
-        String preFilePath = matcher.group(1);
-        // System.out.println("Process the file: " + preFilePath);
-        return new File(preFilePath);
-      }
+    private static Logger log = Logger.getLogger(GoogleDrive2.class);
+
+    //  public static final String DEFAULT_PULL_COMMAND=DEFAULT_EXECUTABLE+" pull -export xls -quiet=true --id %s"; //worked with 0.3.1
+    private static final String DEFAULT_PULL_COMMAND = " pull -export xls -no-prompt --id %s"; // 0.3.7+ changed its output that we parse
+    private static final String DEFAULT_WORKING_FOLDER = "google_drive";
+
+    private String googleSheetPullCommand;
+    private String googleSheetWorkingFolder;
+
+    private static String getDefaultExecutable() {
+        return Paths.get(SystemUtils.getUserHome().getAbsolutePath(), determineGDriveExecutable()).toString();
     }
-    return null;
-    // System.out.println(exec.exitValue());
-  }
-  
-  public int getHeaderRow(){
-    return 0;
-  }
-  
-  public boolean valid(Map<String,String> entry){
-    return true;
-  }
-  
-  public List<Map<String,String>> parseExcelDocument(File file) throws FileNotFoundException, IOException{
-    // parse excel file using apache poi
-    // read out "tasks" and create/update solutions
-    // use timestamp (column A) as the unique identifier (if in doubt i'll hash it with the requester's username)
-    List<Map<String,String>> entries=new ArrayList<Map<String,String>>();
-    FileInputStream in=null;
-    if (file==null || !file.exists()) return new ArrayList<Map<String,String>>();
-    try{
-      in=new FileInputStream(file);
-      XSSFWorkbook wb=new XSSFWorkbook(in);
-      XSSFSheet s=wb.getSheetAt(0);
-      int maxColumns=20;
-      
-      for(int iRow=getHeaderRow()+1;iRow<=s.getLastRowNum();iRow++){
-        Map<String,String> e=new HashMap<String,String>();
-        for(int iColumn=0;iColumn<=maxColumns;iColumn++){
-          if (s.getRow(getHeaderRow()).getCell(iColumn)==null) continue;
-          String header=s.getRow(getHeaderRow()).getCell(iColumn).getStringCellValue();
-          XSSFRow row = s.getRow(iRow);
-          if (row==null) break; // next line/row
-          XSSFCell cell=row.getCell(iColumn);
-          if (cell==null) continue; // try next cell/column
-          
-            try{
-              e.put(header, cell.getStringCellValue());
-            }catch(Exception ex){}
-            if (!e.containsKey(header))
-              try{
-                e.put(header, cell.getDateCellValue().toString());
-              }catch(Exception ex){}
-          
+
+    private static String getDefaultPullCommand() {
+        return getDefaultExecutable() + DEFAULT_PULL_COMMAND;
+    }
+
+    private static String getDefaultWorkingFolder() {
+        return Paths.get(SystemUtils.getUserHome().getAbsolutePath(), DEFAULT_WORKING_FOLDER).toString();
+    }
+
+    GoogleDrive2() {
+        this.googleSheetPullCommand = DEFAULT_PULL_COMMAND;
+        this.googleSheetWorkingFolder = DEFAULT_WORKING_FOLDER;
+    }
+
+    public GoogleDrive2(String googleSheetPullCommand, String googleSheetWorkingFolder) {
+        this.googleSheetPullCommand = googleSheetPullCommand;
+        this.googleSheetWorkingFolder = googleSheetWorkingFolder;
+    }
+
+    File downloadFile(String fileId) throws IOException, InterruptedException {
+        String command = String.format(googleSheetPullCommand, System.getProperty("user.name"), fileId);
+
+        String googleDrivePath = String.format(googleSheetWorkingFolder, System.getProperty("user.name"));
+        File workingFolder = new File(googleDrivePath);
+        if (!workingFolder.mkdirs()) { // just in case it's not there
+            throw new IllegalStateException("Unable to create working folder: " + workingFolder.getAbsolutePath());
         }
-        
-        if (valid(e)){
-          e.put("ROW_#", String.valueOf(iRow));
-          entries.add(e);
+
+        log.debug("Using working folder: " + workingFolder.getAbsolutePath());
+        log.debug("Downloading google file: " + fileId);
+        log.debug("Command: " + command);
+
+        if (googleDrivePath.contains("google")) {
+            recursivelyDelete(workingFolder);
+        } else {
+            log.warn("Not cleaning working folder unless it contains the name 'google' - for safety reasons");
         }
-      }
-    }finally{
-      IOUtils.closeQuietly(in);
-    }
-    return entries;
-  }
-  
-  private void recursivelyDelete(File file){
-    for(File f:file.listFiles()){
-      if (!f.getName().startsWith(".") && f.isDirectory())
-        recursivelyDelete(f);
-      if (!f.getName().startsWith("."))
-        f.delete();
-    }
-  }
-  
-  public static void initialise(){ //ie. download gdrive executable if necessary
-    if (!new File(GoogleDrive2.getDefaultExecutable()).exists()){
-      // attempt to download it
-    	File credsFile=new File(new File(GoogleDrive2.getDefaultWorkingFolder(), ".gd"), "credentials.json");
-      try{
-        String url="https://github.com/odeke-em/drive/releases/download/v0.3.9/drive_linux";
-        
-        log.info("Downloading gdrive from: "+url);
-        new DownloadFile().get(url, new File(GoogleDrive2.getDefaultExecutable()).getParentFile(), PosixFilePermission.OTHERS_EXECUTE);
-        
-        credsFile.getParentFile().mkdirs();
-        log.info("Deploying credentials.json in: "+credsFile);
-        
-        InputStream is=GoogleDrive2.class.getClassLoader().getResourceAsStream("/gd_credentials.json");
-        if (null!=is){
-        	log.info("... from internal classloader path of '/gd_credentials.json'");
-        	IOUtils.copy(is, new FileOutputStream(credsFile));
-        }else if (null!=System.getenv("GD_CREDENTIALS")){
-        	log.info("... from env variable 'GD_CREDENTIALS'");
-        	IOUtils.write(System.getenv("GD_CREDENTIALS").getBytes(), new FileOutputStream(credsFile));
-        }else{
-        	log.error("no gdrive creds specified in either resources, or system props");
+
+        Process exec = Runtime.getRuntime().exec(command, null, workingFolder);
+
+        exec.waitFor();
+        String syserr = IOUtils.toString(exec.getErrorStream());
+        String sysout = IOUtils.toString(exec.getInputStream());
+        System.out.println("sysout=\"" + sysout + "\"; syserr=\"" + syserr + "\"");
+        if (!sysout.contains("Resolving...") && !sysout.contains("Everything is up-to-date"))
+            throw new RuntimeException("Error running google drive script: " + sysout);
+        if (!sysout.contains("Everything is up-to-date")) {
+            // System.out.println("Do Nothing");
+            // return null;
+            // } else {
+            Pattern p = Pattern.compile("to '(.+)'$");
+            Matcher matcher = p.matcher(sysout);
+            if (matcher.find()) {
+                String preFilePath = matcher.group(1);
+                // System.out.println("Process the file: " + preFilePath);
+                return new File(preFilePath);
+            }
         }
-        log.info("drive credentials file contains: "+IOUtils.toString(new FileInputStream(credsFile)));
-        
-      }catch(Exception e){
-        System.out.println("Failed to initialise gdrive and/or credentials, cleaning up exe and creds");
-        credsFile.delete();
-        new File(GoogleDrive2.getDefaultExecutable()).delete();
-        e.printStackTrace();
-      }
-    }else{
-      log.info("gdrive already initialised. Existing binary is here: "+GoogleDrive2.getDefaultExecutable());
+        return null;
+        // System.out.println(exec.exitValue());
     }
-  }
-  
+
+    private int getHeaderRow() {
+        return 0;
+    }
+
+    private boolean valid(Map<String, String> entry) {
+        return true;
+    }
+
+    List<Map<String, String>> parseExcelDocument(File file) throws FileNotFoundException, IOException {
+        // parse excel file using apache poi
+        // read out "tasks" and create/update solutions
+        // use timestamp (column A) as the unique identifier (if in doubt i'll hash it with the requester's username)
+        List<Map<String, String>> entries = new ArrayList<>();
+        FileInputStream in = null;
+        if (file == null || !file.exists()) return new ArrayList<>();
+        try {
+            in = new FileInputStream(file);
+            XSSFWorkbook wb = new XSSFWorkbook(in);
+            XSSFSheet s = wb.getSheetAt(0);
+            int maxColumns = 20;
+
+            for (int iRow = getHeaderRow() + 1; iRow <= s.getLastRowNum(); iRow++) {
+                Map<String, String> e = new HashMap<>();
+                for (int iColumn = 0; iColumn <= maxColumns; iColumn++) {
+                    if (s.getRow(getHeaderRow()).getCell(iColumn) == null) continue;
+                    String header = s.getRow(getHeaderRow()).getCell(iColumn).getStringCellValue();
+                    XSSFRow row = s.getRow(iRow);
+                    if (row == null) break; // next line/row
+                    XSSFCell cell = row.getCell(iColumn);
+                    if (cell == null) continue; // try next cell/column
+
+                    try {
+                        e.put(header, cell.getStringCellValue());
+                    } catch (Exception ignored) {
+                    }
+                    if (!e.containsKey(header))
+                        try {
+                            e.put(header, cell.getDateCellValue().toString());
+                        } catch (Exception ignored) {
+                        }
+
+                }
+
+                if (valid(e)) {
+                    e.put("ROW_#", String.valueOf(iRow));
+                    entries.add(e);
+                }
+            }
+        } finally {
+            IOUtils.closeQuietly(in);
+        }
+        return entries;
+    }
+
+    private void recursivelyDelete(File file) {
+        File[] files = file.listFiles();
+        if (ArrayUtils.isNotEmpty(files)) {
+            for (File f : files) {
+                if (!f.getName().startsWith(".") && f.isDirectory())
+                    recursivelyDelete(f);
+                if (!f.getName().startsWith(".")) {
+                    boolean result = f.delete();
+                    if (!result) {
+                        log.warn("Could not delete file: " + f.getName());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Determines the appropriate gdrive executable to utilize, based on OS
+     * @return The appropriate gdrive executable
+     */
+    private static String determineGDriveExecutable() {
+        if (SystemUtils.IS_OS_MAC_OSX) {
+            return "drive_darwin";
+        } else if (SystemUtils.IS_OS_LINUX) {
+            return "drive_linux";
+        } else {
+            throw new IllegalStateException("Unable to determine OS from os.name: " + System.getProperty("os.name"));
+        }
+    }
+
+    /**
+     * Loads the environment credentials, either directly from the string or from the file if specified
+     * @param credsFile The credentials file string
+     * @return True if the credentials string was not empty, false otherwise
+     * @throws IOException If the credentials fail to write locally
+     */
+    private static boolean getEnvironmentCredentials(File credsFile) throws IOException {
+        String credentials = Config.get().getEnvOption("GD_CREDENTIALS");
+        if (StringUtils.isNotEmpty(credentials)) {
+            if (credentials.startsWith("file:")) {
+                IOUtils.write(Files.readAllBytes(Paths.get(credentials.substring(5))), new FileOutputStream(credsFile));
+            } else {
+                IOUtils.write(credentials.getBytes(), new FileOutputStream(credsFile));
+            }
+        }
+        return StringUtils.isNotEmpty(credentials);
+    }
+
+    static void initialise() { //ie. download gdrive executable if necessary
+        if (!new File(GoogleDrive2.getDefaultExecutable()).exists()) {
+            // attempt to download it
+            File credsFile = Paths.get(GoogleDrive2.getDefaultWorkingFolder(), ".gd", "credentials.json").toFile();
+            try {
+
+                String executable = determineGDriveExecutable();
+                String releaseUrl = Config.get().getOption("gdrive.releases.url");
+                Validate.isTrue(releaseUrl != null);
+                String url = Config.get().getOption("gdrive.releases.url") + executable;
+
+                log.info("Downloading gdrive from: " + url);
+                new DownloadFile().get(url, new File(GoogleDrive2.getDefaultExecutable()).getParentFile(), PosixFilePermission.OTHERS_EXECUTE);
+
+                log.debug("Creating directory " + credsFile.getParentFile() + " if necessary.");
+                Files.createDirectories(Paths.get(credsFile.getParent()));
+                log.info("Deploying credentials.json in: " + credsFile);
+
+                InputStream is = GoogleDrive2.class.getClassLoader().getResourceAsStream("/gd_credentials.json");
+                if (null != is) {
+                    log.info("... from internal classloader path of '/gd_credentials.json'");
+                    IOUtils.copy(is, new FileOutputStream(credsFile));
+                } else if (null != Config.get().getEnvOption("GD_CREDENTIALS")) {
+                    log.info("... from env variable 'GD_CREDENTIALS'");
+                    getEnvironmentCredentials(credsFile);
+                } else {
+                    log.error("no gdrive creds specified in either resources, or system props");
+                    throw new IllegalStateException("Must specify gdrive creds on either classpath or environment.");
+                }
+                log.info("drive credentials file contains: " + IOUtils.toString(new FileInputStream(credsFile)));
+
+            } catch (Exception e) {
+                log.error("Failed to initialise gdrive and/or credentials, cleaning up exe and creds: ", e);
+                if (credsFile.exists()) {
+                    Validate.isTrue(credsFile.delete());
+                }
+                File gd = new File(GoogleDrive2.getDefaultExecutable());
+                if (gd.exists()) {
+                    Validate.isTrue(gd.delete());
+                }
+            }
+        } else {
+            log.info("gdrive already initialised. Existing binary is here: " + GoogleDrive2.getDefaultExecutable());
+        }
+    }
+
 }

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -17,6 +17,7 @@
 		}
 	],
 	"options": {
+		"gdrive.releases.url": "https://github.com/odeke-em/drive/releases/download/v0.3.9/",
 		"login.enabled": "false",
 		"root": "${configLocation}",
 		"_graphs-proxy": "http://localhost:8083/ninja-roxy",


### PR DESCRIPTION
General improvements for the Config, GoogleDrive2 classes:

* Compatibility for folks running OS X (code referred to several Linux only constructs - /home/* vs /Users/*, drive_linux vs drive_darwin, etc)
* Moved hard-coded URLs for drive_* to configs for easier updating
* Addition of dotenv (https://github.com/cdimascio/java-dotenv) for easier maintenance of environment variables
* Allowed credentials to be read from a file, rather than inserted directly into the environment variables
* Preferred usage of NIO file ops (Files.createDirectories() instead of File.mkdir(), etc) because of the former's preference for failing fast vs boolean returned values that are often unchecked
* Increased usage of Validate.* for better pre-requisite checks