### PR TITLE
Backend Quarkus Scorecard: Adding support for leaderboards

### DIFF
--- a/quarkus/scorecard-service/src/main/java/com/redhat/services/ninja/controller/ScorecardResource.java
+++ b/quarkus/scorecard-service/src/main/java/com/redhat/services/ninja/controller/ScorecardResource.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,6 +16,10 @@ import java.util.Optional;
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class ScorecardResource {
+
+    private static final Comparator<Scorecard> LEADERBOARD_COMPARATOR
+            = Comparator.comparingDouble(Scorecard::getTotal).reversed();
+
     @Inject
     @RestClient
     ScorecardClient scorecardClient;
@@ -46,6 +51,8 @@ public class ScorecardResource {
 
     @GET
     public List<Scorecard> getAll() {
-        return scorecardClient.getAll();
+        List<Scorecard> scorecards = scorecardClient.getAll();
+        scorecards.sort(LEADERBOARD_COMPARATOR);
+        return scorecards;
     }
 }

--- a/quarkus/scorecard-service/src/test/java/com/redhat/services/ninja/controller/ScorecardResourceTest.java
+++ b/quarkus/scorecard-service/src/test/java/com/redhat/services/ninja/controller/ScorecardResourceTest.java
@@ -5,18 +5,20 @@ import com.redhat.services.ninja.client.ScorecardClient;
 import com.redhat.services.ninja.entity.Scorecard;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +28,7 @@ class ScorecardResourceTest extends AbstractResourceTest {
     @RestClient
     ScorecardClient client;
 
-    static private Map<String, Scorecard> scorecards = new HashMap<>();
+    static private final Map<String, Scorecard> scorecards = new HashMap<>();
 
 
     @BeforeAll
@@ -46,6 +48,8 @@ class ScorecardResourceTest extends AbstractResourceTest {
                 .thenAnswer(a -> a.getArgument(0));
 
         when(client.get(any())).thenAnswer(a -> scorecards.get(a.getArgument(0)));
+
+        when(client.getAll()).thenReturn(new ArrayList<>(scorecards.values()));
     }
 
     @Test
@@ -91,5 +95,18 @@ class ScorecardResourceTest extends AbstractResourceTest {
                 .get("scorecard/non_existing_ninja")
                 .then()
                 .statusCode(404);
+    }
+
+    @Test
+    void getAllScorecards() {
+        List<Scorecard> scorecards = given()
+                .when()
+                .get("scorecard")
+                .as(new TypeRef<>() {
+                });
+
+        for (int i = 0; i < scorecards.size() - 1; i++) {
+            assertTrue(scorecards.get(i).getTotal() >= scorecards.get(i + 1).getTotal());
+        }
     }
 }


### PR DESCRIPTION
Getting all scorecards now returns them in a descending order comparing total.